### PR TITLE
Prevent timing attacks against hash checking

### DIFF
--- a/hawk.go
+++ b/hawk.go
@@ -553,7 +553,7 @@ func (auth *Auth) PayloadHash(contentType string) hash.Hash {
 // ValidHash writes the final newline to h and checks if it matches auth.Hash.
 func (auth *Auth) ValidHash(h hash.Hash) bool {
 	h.Write([]byte("\n"))
-	return bytes.Equal(h.Sum(nil), auth.Hash)
+	return hmac.Equal(h.Sum(nil), auth.Hash)
 }
 
 // SetHash writes the final newline to h and sets auth.Hash to the sum. This is


### PR DESCRIPTION
ref: https://codahale.com/a-lesson-in-timing-attacks/

Golang provides the built in hmac.Equal which checks equality in
constant time. In contrast, bytes.Equal returns as soon as a byte does
not match
