### PR TITLE
Upstream fixes

### DIFF
--- a/hawk.go
+++ b/hawk.go
@@ -294,7 +294,6 @@ func NewURLAuth(uri string, creds *Credentials, tsOffset time.Duration) (*Auth, 
 		Method:      "GET",
 		Credentials: *creds,
 		Timestamp:   Now().Add(tsOffset),
-		Nonce:       nonce(),
 	}
 	if u.Path != "" {
 		// url.Parse unescapes the path, which is unexpected

--- a/hawk.go
+++ b/hawk.go
@@ -283,7 +283,7 @@ func NewRequestAuth(req *http.Request, creds *Credentials, tsOffset time.Duratio
 	return auth
 }
 
-// NewRequestAuth builds a client Auth based on uri and creds. tsOffset will be
+// NewURLAuth builds a client Auth based on uri and creds. tsOffset will be
 // applied to Now when setting the timestamp.
 func NewURLAuth(uri string, creds *Credentials, tsOffset time.Duration) (*Auth, error) {
 	u, err := url.Parse(uri)

--- a/hawk.go
+++ b/hawk.go
@@ -663,7 +663,6 @@ func (auth *Auth) UpdateOffset(header string) (time.Duration, error) {
 	var err error
 	var ts time.Time
 	var tsm []byte
-	var errMsg string
 
 	for _, match := range matches {
 		switch match[1] {
@@ -678,13 +677,7 @@ func (auth *Auth) UpdateOffset(header string) (time.Duration, error) {
 			if err != nil {
 				return 0, AuthFormatError{"tsm", "malformed base64 encoding"}
 			}
-		case "error":
-			errMsg = match[2]
 		}
-	}
-
-	if errMsg != "Stale timestamp" {
-		return 0, AuthFormatError{"error", "missing or unknown"}
 	}
 
 	if !hmac.Equal(tsm, auth.tsMac(strconv.FormatInt(ts.Unix(), 10))) {

--- a/hawk.go
+++ b/hawk.go
@@ -294,6 +294,7 @@ func NewURLAuth(uri string, creds *Credentials, tsOffset time.Duration) (*Auth, 
 		Method:      "GET",
 		Credentials: *creds,
 		Timestamp:   Now().Add(tsOffset),
+		Nonce:       nonce(),
 	}
 	if u.Path != "" {
 		// url.Parse unescapes the path, which is unexpected


### PR DESCRIPTION
This contains two upstream fixes:

* https://github.com/tent/hawk-go/pull/11 (accepted and landed upstream)
* https://github.com/tent/hawk-go/pull/12 (awaiting review upstream, but clearly valid)

Since the original tent repo seems not to be very actively maintained, I also checked through other forks to see if there were any local security fixes that weren't upstreamed, but there didn't seem to be any.

Note, since I merged the upstream changes, this also pulled in https://github.com/tent/hawk-go/pull/9 and https://github.com/tent/hawk-go/pull/10 which adds a bit of noise to the history, but results in no code changes. However, it keeps the repository history aligned with upstream, which should ease future merges, so is probably better than filtering them out.

CC @ajvb @jvehent